### PR TITLE
feat(visitors): support export extensions

### DIFF
--- a/src/visitors.js
+++ b/src/visitors.js
@@ -72,6 +72,17 @@ export default safeguardVisitors({
   // Source: export {};
   // Instrumented: ++count; export {};
   ExportDeclaration(path, state) {
+    // Specifiers are not instrumentable:
+    if (path.has('specifiers')) {
+      path.get('specifiers').forEach(specifier => {
+        markAsInstrumented(specifier.get('local'));
+        markAsInstrumented(specifier.get('exported'));
+      });
+    }
+    // Source is not instrumentable:
+    if (path.has('source')) {
+      markAsInstrumented(path.get('source'));
+    }
     instrumentStatement(path, state, ['export', 'statement']);
   },
 

--- a/test/fixture/export-extensions-statements.fixture.js
+++ b/test/fixture/export-extensions-statements.fixture.js
@@ -1,0 +1,10 @@
+// The path is weird because it is relative to test/spec/helpers/run.js
+
+// one export statement
+export {foo, a} from '../../fixture/export-statements.fixture.js';
+
+// one export statement
+export {
+  foo as fooExported,
+  a as aExported
+} from '../../fixture/export-statements.fixture.js';

--- a/test/spec/exports.spec.js
+++ b/test/spec/exports.spec.js
@@ -47,3 +47,29 @@ test('coverage should count export function declarations', t => {
     t.equal(executedNeverFunctionLocations.length, 1);
   });
 });
+
+test('coverage should count export extensions as "export"', t => {
+  t.plan(2);
+  runFixture('export-extensions-statements').then(({locations}) => {
+    const exportLocations = locations.filter(isExport);
+
+    // There is only one location per export statement, because
+    // export extensions contents are not instrumentable:
+    t.equal(exportLocations.length, 2);
+    // All export locations should only be executed once:
+    t.ok(exportLocations.every(el => el.count === 1));
+  });
+});
+
+test('coverage should count export extensions as "statement"', t => {
+  t.plan(2);
+  runFixture('export-extensions-statements').then(({locations}) => {
+    const statementLocations = locations.filter(isStatement);
+
+    // There is only one location per export statement, because
+    // export extensions contents are not instrumentable:
+    t.equal(statementLocations.length, 2);
+    // All export statement locations should only be executed once:
+    t.ok(statementLocations.every(el => el.count === 1));
+  });
+});


### PR DESCRIPTION
    export {foo as bar} from 'somewhere';