### PR TITLE
feat(marker): encode coverage data

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/esnext-coverage/babel-plugin-transform-esnext-coverage",
   "dependencies": {
-    "babel-template": "^6.16.0"
+    "babel-template": "^6.16.0",
+    "esnext-coverage-analytics": "^0.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -43,7 +44,7 @@
   "esnextcoverage": {
     "only": "src/**.js",
     "reporters": [
-      {"formatter": "html", "outFile": "reports/coverage/coverage.html"}
+      {"outFile": "reports/coverage/coverage.json"}
     ],
     "thresholds": {
       "global": {

--- a/src/marker.js
+++ b/src/marker.js
@@ -1,4 +1,5 @@
 import {types} from 'babel-core';
+import {codec} from 'esnext-coverage-analytics';
 import {getCoverageMeta} from './meta';
 
 /**
@@ -31,12 +32,11 @@ export function isInstrumented(pathOrNode) {
  */
 export function createMarker(state, {loc, tags}, node) {
   const {locations, variable} = getCoverageMeta(state);
-  const id = locations.length;
-  const args = [types.numericLiteral(id)];
+  const args = [types.numericLiteral(locations.length)];
   if (node) {
     args.push(node);
   }
   const marker = types.callExpression(variable, args);
-  locations.push({id, loc, tags, count: 0});
+  locations.push(codec.encode({loc, tags, count: 0}));
   return markAsInstrumented(marker);
 }

--- a/src/templates/prelude.js
+++ b/src/templates/prelude.js
@@ -1,14 +1,12 @@
 /* eslint-disable no-undef, no-unused-vars */
 
-const VARIABLE = (context => {
+const VARIABLE = (function (context) {
   const locations = JSON.parse(LOCATIONS);
   context[NAMESPACE] = context[NAMESPACE] || {};
-  context[NAMESPACE][FILEPATH] = {
-    path: FILEPATH,
-    locations
-  };
-  return (index, value) => {
-    locations[index].count += 1;
+  context[NAMESPACE].files = context[NAMESPACE].files || {};
+  context[NAMESPACE].files[FILEPATH] = {coverage: locations};
+  return function (index, value) {
+    locations[index][0] += 1;
     return value;
   };
 })(

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -169,7 +169,7 @@ export default safeguardVisitors({
 
   Function(path, state) {
     if (path.node.kind === 'constructor') {
-      instrumentBlock('body', path.get('body'), state, ['function', '_constructor']);
+      instrumentBlock('body', path.get('body'), state, ['function', 'constructor']);
     } else {
       instrumentBlock('body', path.get('body'), state, ['function']);
     }

--- a/test/spec/array-expressions.spec.js
+++ b/test/spec/array-expressions.spec.js
@@ -8,7 +8,7 @@ import {isStatement, isExpression} from './helpers/tag-assert';
 
 test('coverage should count array expressions', t => {
   t.plan(3);
-  runFixture('array-expressions').then(({locations}) => {
+  runFixture('array-expressions').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations

--- a/test/spec/assignment-expressions.spec.js
+++ b/test/spec/assignment-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression} from './helpers/tag-assert';
 
 test('coverage should count assignment expressions', t => {
   t.plan(2);
-  runFixture('assignment-expressions').then(({locations}) => {
+  runFixture('assignment-expressions').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);

--- a/test/spec/binary-expressions.spec.js
+++ b/test/spec/binary-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression} from './helpers/tag-assert';
 
 test('coverage should count binary expressions', t => {
   t.plan(2);
-  runFixture('binary-expressions').then(({locations}) => {
+  runFixture('binary-expressions').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);

--- a/test/spec/break-statements.spec.js
+++ b/test/spec/break-statements.spec.js
@@ -8,7 +8,7 @@ import {isStatement} from './helpers/tag-assert';
 
 test('coverage should count break statements', t => {
   t.plan(2);
-  runFixture('break-statements').then(({locations}) => {
+  runFixture('break-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceStatementLocations = statementLocations
       .filter(el => el.count === 1);

--- a/test/spec/call-expressions.spec.js
+++ b/test/spec/call-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression} from './helpers/tag-assert';
 
 test('coverage should count call expression', t => {
   t.plan(2);
-  runFixture('call-expressions').then(({locations}) => {
+  runFixture('call-expressions').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);

--- a/test/spec/classes.spec.js
+++ b/test/spec/classes.spec.js
@@ -13,7 +13,7 @@ import {
 
 test('coverage should count class declarations', t => {
   t.plan(3);
-  runFixture('classes').then(({locations}) => {
+  runFixture('classes').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceStatementLocations = statementLocations
       .filter(l => l.count === 1);
@@ -35,7 +35,7 @@ test('coverage should count class declarations', t => {
 
 test('coverage should count expressions in classes', t => {
   t.plan(3);
-  runFixture('classes').then(({locations}) => {
+  runFixture('classes').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(location => location.count === 1);
@@ -57,7 +57,7 @@ test('coverage should count expressions in classes', t => {
 
 test('coverage should count class constructors', t => {
   t.plan(1);
-  runFixture('classes').then(({locations}) => {
+  runFixture('classes').then(locations => {
     const constructorLocations = locations.filter(isConstructor);
     // There is only one constructor:
     t.equal(constructorLocations.length, 1);
@@ -66,7 +66,7 @@ test('coverage should count class constructors', t => {
 
 test('coverage should count class methods and track their executions', t => {
   t.plan(3);
-  runFixture('classes').then(({locations}) => {
+  runFixture('classes').then(locations => {
     const functionLocations = locations.filter(isFunction);
     const executedOnceFunctionLocations = functionLocations
       .filter(l => l.count === 1);

--- a/test/spec/conditional-expressions.spec.js
+++ b/test/spec/conditional-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count conditional expressions', t => {
   t.plan(3);
-  runFixture('conditional-expressions').then(({locations}) => {
+  runFixture('conditional-expressions').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedNeverExpressionLocations = expressionLocations
       .filter(l => l.count === 0);
@@ -23,7 +23,7 @@ test('coverage should count conditional expressions', t => {
 
 test('coverage should count conditional expressions as branches', t => {
   t.plan(3);
-  runFixture('conditional-expressions').then(({locations}) => {
+  runFixture('conditional-expressions').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedNeverBranchLocations = branchLocations
       .filter(l => l.count === 0);
@@ -38,7 +38,7 @@ test('coverage should count conditional expressions as branches', t => {
 
 test('coverage should instrument conditional expression statements', t => {
   t.plan(2);
-  runFixture('conditional-expressions').then(({locations}) => {
+  runFixture('conditional-expressions').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceExpressionLocations = statementLocations
       .filter(l => l.count === 1);

--- a/test/spec/continue-statements.spec.js
+++ b/test/spec/continue-statements.spec.js
@@ -8,7 +8,7 @@ import {isStatement} from './helpers/tag-assert';
 
 test('coverage should count continue statements', t => {
   t.plan(3);
-  runFixture('continue-statements').then(({locations}) => {
+  runFixture('continue-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceStatementLocations = statementLocations
       .filter(el => el.count === 1);

--- a/test/spec/directives.spec.js
+++ b/test/spec/directives.spec.js
@@ -8,7 +8,7 @@ import {isDirective} from './helpers/tag-assert';
 
 test('coverage should count directives', t => {
   t.plan(3);
-  runFixture('directives').then(({locations}) => {
+  runFixture('directives').then(locations => {
     const directiveLocations = locations.filter(isDirective);
     const executedOnceDirectiveLocations = directiveLocations
       .filter(l => l.count === 1);

--- a/test/spec/do-while-statements.spec.js
+++ b/test/spec/do-while-statements.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count do-while statements', t => {
   t.plan(2);
-  runFixture('do-while-statements').then(({locations}) => {
+  runFixture('do-while-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedStatementLocations = statementLocations
       .filter(el => el.count === 1);
@@ -22,7 +22,7 @@ test('coverage should count do-while statements', t => {
 
 test('coverage should count do-while test expressions', t => {
   t.plan(2);
-  runFixture('do-while-statements').then(({locations}) => {
+  runFixture('do-while-statements').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);
@@ -36,7 +36,7 @@ test('coverage should count do-while test expressions', t => {
 
 test('coverage should count do-while branches', t => {
   t.plan(2);
-  runFixture('do-while-statements').then(({locations}) => {
+  runFixture('do-while-statements').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(el => el.count === 1);

--- a/test/spec/empty.spec.js
+++ b/test/spec/empty.spec.js
@@ -1,20 +1,10 @@
-import path from 'path';
 import test from 'tape';
 import runFixture from './helpers/run';
 
-const fixturePath = path.resolve(__dirname, '../fixture/empty.fixture.js');
-
-test('coverage should have a valid path string', t => {
-  t.plan(1);
-  runFixture('empty').then(fileCoverage => {
-    t.equal(fileCoverage.path, fixturePath);
-  });
-});
-
 test('coverage should have an empty locations array', t => {
   t.plan(2);
-  runFixture('empty').then(fileCoverage => {
-    t.equal(Array.isArray(fileCoverage.locations), true);
-    t.equal(fileCoverage.locations.length, 0);
+  runFixture('empty').then(locations => {
+    t.equal(Array.isArray(locations), true);
+    t.equal(locations.length, 0);
   });
 });

--- a/test/spec/exports.spec.js
+++ b/test/spec/exports.spec.js
@@ -12,7 +12,7 @@ import {
 
 test('coverage should count exports', t => {
   t.plan(2);
-  runFixture('export-statements').then(({locations}) => {
+  runFixture('export-statements').then(locations => {
     const exportLocations = locations.filter(isExport);
     const executedOnceExportLocations = exportLocations
       .filter(el => el.count === 1);
@@ -24,7 +24,7 @@ test('coverage should count exports', t => {
 
 test('coverage should count exports as statements', t => {
   t.plan(2);
-  runFixture('export-statements').then(({locations}) => {
+  runFixture('export-statements').then(locations => {
     const exportStatements = locations.filter(isStatement);
     const executedOnceStatements = exportStatements
       .filter(el => el.count === 1);
@@ -36,7 +36,7 @@ test('coverage should count exports as statements', t => {
 
 test('coverage should count export function declarations', t => {
   t.plan(2);
-  runFixture('export-statements').then(({locations}) => {
+  runFixture('export-statements').then(locations => {
     const functionLocations = locations.filter(isFunction);
     const executedNeverFunctionLocations = functionLocations
       .filter(el => el.count === 0);
@@ -50,7 +50,7 @@ test('coverage should count export function declarations', t => {
 
 test('coverage should count export extensions as "export"', t => {
   t.plan(2);
-  runFixture('export-extensions-statements').then(({locations}) => {
+  runFixture('export-extensions-statements').then(locations => {
     const exportLocations = locations.filter(isExport);
 
     // There is only one location per export statement, because
@@ -63,7 +63,7 @@ test('coverage should count export extensions as "export"', t => {
 
 test('coverage should count export extensions as "statement"', t => {
   t.plan(2);
-  runFixture('export-extensions-statements').then(({locations}) => {
+  runFixture('export-extensions-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
 
     // There is only one location per export statement, because

--- a/test/spec/for-in-statements.spec.js
+++ b/test/spec/for-in-statements.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count for-in statements', t => {
   t.plan(2);
-  runFixture('for-in-statements').then(({locations}) => {
+  runFixture('for-in-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceStatementLocations = statementLocations
       .filter(el => el.count === 1);
@@ -22,7 +22,7 @@ test('coverage should count for-in statements', t => {
 
 test('coverage should count for-in statement test expressions', t => {
   t.plan(2);
-  runFixture('for-in-statements').then(({locations}) => {
+  runFixture('for-in-statements').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);
@@ -36,7 +36,7 @@ test('coverage should count for-in statement test expressions', t => {
 
 test.skip('coverage should count for-in statement branches', t => {
   t.plan(2);
-  runFixture('for-in-statements').then(({locations}) => {
+  runFixture('for-in-statements').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(el => el.count === 1);

--- a/test/spec/for-of-statements.spec.js
+++ b/test/spec/for-of-statements.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count for-of statements', t => {
   t.plan(2);
-  runFixture('for-of-statements').then(({locations}) => {
+  runFixture('for-of-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceStatementLocations = statementLocations
       .filter(el => el.count === 1);
@@ -22,7 +22,7 @@ test('coverage should count for-of statements', t => {
 
 test('coverage should count for-of statement test expressions', t => {
   t.plan(2);
-  runFixture('for-of-statements').then(({locations}) => {
+  runFixture('for-of-statements').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);
@@ -36,7 +36,7 @@ test('coverage should count for-of statement test expressions', t => {
 
 test.skip('coverage should count for-of statement branches', t => {
   t.plan(2);
-  runFixture('for-of-statements').then(({locations}) => {
+  runFixture('for-of-statements').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(el => el.count === 1);

--- a/test/spec/for-statements.spec.js
+++ b/test/spec/for-statements.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count for-statement statements', t => {
   t.plan(2);
-  runFixture('for-statements').then(({locations}) => {
+  runFixture('for-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedStatementLocations = statementLocations
       .filter(el => el.count === 1)
@@ -23,7 +23,7 @@ test('coverage should count for-statement statements', t => {
 
 test('coverage should count for-statement test expressions', t => {
   t.plan(3);
-  runFixture('for-statements').then(({locations}) => {
+  runFixture('for-statements').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);
@@ -41,7 +41,7 @@ test('coverage should count for-statement test expressions', t => {
 
 test('coverage should count conditionless for-statements', t => {
   t.plan(2);
-  runFixture('for-statements-no-condition').then(({locations}) => {
+  runFixture('for-statements-no-condition').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const statementLocations = locations.filter(isStatement);
 
@@ -54,7 +54,7 @@ test('coverage should count conditionless for-statements', t => {
 
 test.skip('coverage should count for-statement branches', t => {
   t.plan(2);
-  runFixture('for-statements').then(({locations}) => {
+  runFixture('for-statements').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedBranchLocations = branchLocations
       .filter(el => el.count === 1)

--- a/test/spec/functions.spec.js
+++ b/test/spec/functions.spec.js
@@ -8,7 +8,7 @@ import {isFunction, isStatement} from './helpers/tag-assert';
 
 test('coverage should count function declarations', t => {
   t.plan(3);
-  runFixture('function-declarations').then(({locations}) => {
+  runFixture('function-declarations').then(locations => {
     const statementLocations = locations.filter(isStatement);
     t.equal(statementLocations.length, 2);
     t.equal(statementLocations[0].count, 1);
@@ -18,7 +18,7 @@ test('coverage should count function declarations', t => {
 
 test('coverage should count function executions', t => {
   t.plan(4);
-  runFixture('function-executions').then(({locations}) => {
+  runFixture('function-executions').then(locations => {
     const functionLocations = locations.filter(isFunction);
     t.equal(functionLocations.length, 3);
     t.equal(functionLocations[0].count, 0);
@@ -33,7 +33,7 @@ test('coverage should count function executions', t => {
 
 test('coverage should count fat arrow function declarations', t => {
   t.plan(3);
-  runFixture('function-arrow-fat-declarations').then(({locations}) => {
+  runFixture('function-arrow-fat-declarations').then(locations => {
     const statementLocations = locations.filter(isStatement);
     t.equal(statementLocations.length, 2);
     t.equal(statementLocations[0].count, 1);
@@ -43,7 +43,7 @@ test('coverage should count fat arrow function declarations', t => {
 
 test('coverage should count fat arrow function executions', t => {
   t.plan(3);
-  runFixture('function-arrow-fat-executions').then(({locations}) => {
+  runFixture('function-arrow-fat-executions').then(locations => {
     const functionLocations = locations.filter(isFunction);
     t.equal(functionLocations.length, 2);
     t.equal(functionLocations[0].count, 0);

--- a/test/spec/helpers/run.js
+++ b/test/spec/helpers/run.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import {runInNewContext} from 'vm';
+import {codec} from 'esnext-coverage-analytics';
 import transform from './transform';
 import {defaultNamespace as namespace} from '../../../src/prelude';
 
@@ -7,13 +8,15 @@ export default function runFixture(fixtureName) {
   const fixturePath = path.resolve(__dirname, `../../fixture/${fixtureName}.fixture.js`);
   return transform(fixturePath)
     .then(({code}) => {
+      // console.log(code);
       const sandbox = {
         require,
         global: {},
         exports: {}
       };
       runInNewContext(code, sandbox);
-      return sandbox.global[namespace][fixturePath];
+      const fileCoverage = sandbox.global[namespace].files[fixturePath].coverage;
+      return codec.decodeAll(fileCoverage);
     })
     .catch(error => console.error(error)); // eslint-disable-line no-console
 }

--- a/test/spec/helpers/tag-assert.js
+++ b/test/spec/helpers/tag-assert.js
@@ -7,7 +7,7 @@ export function isFunction({tags}) {
 }
 
 export function isConstructor({tags}) {
-  return tags.some(tag => tag === '_constructor');
+  return tags.some(tag => tag === 'constructor');
 }
 
 export function isBranch({tags}) {

--- a/test/spec/if-statements.spec.js
+++ b/test/spec/if-statements.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isBranch} from './helpers/tag-assert';
 
 test('coverage should count if-statement test expressions', t => {
   t.plan(2);
-  runFixture('if-statements').then(({locations}) => {
+  runFixture('if-statements').then(locations => {
     const testExpressions = locations.filter(isExpression);
     const executedOnceTestExpressions = testExpressions
       .filter(l => l.count === 1);
@@ -22,7 +22,7 @@ test('coverage should count if-statement test expressions', t => {
 
 test('coverage should count if-statement branches', t => {
   t.plan(2);
-  runFixture('if-statements').then(({locations}) => {
+  runFixture('if-statements').then(locations => {
     const testBranches = locations.filter(isBranch);
     const executedOnceTestBranches = testBranches
       .filter(l => l.count === 1);
@@ -36,7 +36,7 @@ test('coverage should count if-statement branches', t => {
 
 test('coverage should count empty branches in if-statements', t => {
   t.plan(3);
-  runFixture('if-statements-empty').then(({locations}) => {
+  runFixture('if-statements-empty').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(l => l.count === 1);
@@ -54,7 +54,7 @@ test('coverage should count empty branches in if-statements', t => {
 
 test('coverage should count blockless branches in if-statements', t => {
   t.plan(3);
-  runFixture('if-statements-no-block').then(({locations}) => {
+  runFixture('if-statements-no-block').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(l => l.count === 1);
@@ -72,7 +72,7 @@ test('coverage should count blockless branches in if-statements', t => {
 
 test('coverage should count missing alternate branches in if-statements', t => {
   t.plan(2);
-  runFixture('if-statements-no-alternate').then(({locations}) => {
+  runFixture('if-statements-no-alternate').then(locations => {
     const testBranches = locations.filter(isBranch);
     const executedOnceTestBranches = testBranches
       .filter(l => l.count === 1);

--- a/test/spec/imports.spec.js
+++ b/test/spec/imports.spec.js
@@ -8,7 +8,7 @@ import {isImport, isStatement} from './helpers/tag-assert';
 
 test('coverage should count import statements as imports', t => {
   t.plan(2);
-  runFixture('import-statements').then(({locations}) => {
+  runFixture('import-statements').then(locations => {
     const importLocations = locations.filter(isImport);
     t.equal(importLocations.length, 1);
     t.equal(importLocations.every(el => el.count === 1), true);
@@ -17,7 +17,7 @@ test('coverage should count import statements as imports', t => {
 
 test('coverage should count import statements as statements', t => {
   t.plan(2);
-  runFixture('import-statements').then(({locations}) => {
+  runFixture('import-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     t.equal(statementLocations.length, 1);
     t.equal(statementLocations.every(el => el.count === 1), true);

--- a/test/spec/logical-expressions.spec.js
+++ b/test/spec/logical-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isBranch} from './helpers/tag-assert';
 
 test('coverage should count logical expressions', t => {
   t.plan(3);
-  runFixture('logical-expressions').then(({locations}) => {
+  runFixture('logical-expressions').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);
@@ -26,7 +26,7 @@ test('coverage should count logical expressions', t => {
 
 test('coverage should count logical branches', t => {
   t.plan(3);
-  runFixture('logical-expressions').then(({locations}) => {
+  runFixture('logical-expressions').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(el => el.count === 1);

--- a/test/spec/objects.spec.js
+++ b/test/spec/objects.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isFunction} from './helpers/tag-assert';
 
 test('coverage should count object properties', t => {
   t.plan(2);
-  runFixture('object-properties').then(({locations}) => {
+  runFixture('object-properties').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(l => l.count === 1);
@@ -22,7 +22,7 @@ test('coverage should count object properties', t => {
 
 test('coverage should count object methods', t => {
   t.plan(3);
-  runFixture('object-methods').then(({locations}) => {
+  runFixture('object-methods').then(locations => {
     const functionLocations = locations.filter(isFunction);
     const executedOnceFunctionLocations = functionLocations
       .filter(l => l.count === 1);
@@ -40,7 +40,7 @@ test('coverage should count object methods', t => {
 
 test('coverage should count expressions in object method declarations', t => {
   t.plan(2);
-  runFixture('object-methods').then(({locations}) => {
+  runFixture('object-methods').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(l => l.count === 1);

--- a/test/spec/switch-cases.spec.js
+++ b/test/spec/switch-cases.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isBranch} from './helpers/tag-assert';
 
 test('coverage should count switch-case test expressions', t => {
   t.plan(2);
-  runFixture('switch-cases').then(({locations}) => {
+  runFixture('switch-cases').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedTestExpressions = expressionLocations
       .filter(el => el.count === 1)
@@ -23,7 +23,7 @@ test('coverage should count switch-case test expressions', t => {
 
 test('coverage should count switch-case blocks as branches', t => {
   t.plan(2);
-  runFixture('switch-cases').then(({locations}) => {
+  runFixture('switch-cases').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedBranchLocations = branchLocations
       .filter(el => el.count === 1)

--- a/test/spec/switch-expressions.spec.js
+++ b/test/spec/switch-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement} from './helpers/tag-assert';
 
 test('coverage should count switch-statement statements', t => {
   t.plan(2);
-  runFixture('switch-statements').then(({locations}) => {
+  runFixture('switch-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedTestExpressions = statementLocations
       .filter(el => el.count === 1)
@@ -23,7 +23,7 @@ test('coverage should count switch-statement statements', t => {
 
 test('coverage should count switch-statement test expressions', t => {
   t.plan(2);
-  runFixture('switch-statements').then(({locations}) => {
+  runFixture('switch-statements').then(locations => {
     const testExpressions = locations.filter(isExpression);
     const executedTestExpressions = testExpressions
       .filter(el => el.count === 1)

--- a/test/spec/try-catch.spec.js
+++ b/test/spec/try-catch.spec.js
@@ -8,7 +8,7 @@ import {isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count try and throw statements', t => {
   t.plan(2);
-  runFixture('try-catch').then(({locations}) => {
+  runFixture('try-catch').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedOnceStatementLocations = statementLocations
       .filter(el => el.count === 1);
@@ -26,7 +26,7 @@ test('coverage should count try and throw statements', t => {
 
 test('coverage should count try-catch branches', t => {
   t.plan(2);
-  runFixture('try-catch').then(({locations}) => {
+  runFixture('try-catch').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(el => el.count === 1);

--- a/test/spec/update-expressions.spec.js
+++ b/test/spec/update-expressions.spec.js
@@ -8,7 +8,7 @@ import {isExpression} from './helpers/tag-assert';
 
 test('coverage should count update expressions', t => {
   t.plan(2);
-  runFixture('update-expressions').then(({locations}) => {
+  runFixture('update-expressions').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1);

--- a/test/spec/variables.spec.js
+++ b/test/spec/variables.spec.js
@@ -8,7 +8,7 @@ import {isVariable, isStatement, isExpression} from './helpers/tag-assert';
 
 test('coverage should count variable declarations as variables', t => {
   t.plan(2);
-  runFixture('variable-declarations').then(({locations}) => {
+  runFixture('variable-declarations').then(locations => {
     const variableLocations = locations.filter(isVariable);
     t.equal(variableLocations.length, 6);
     t.equal(variableLocations.every(el => el.count === 1), true);
@@ -17,7 +17,7 @@ test('coverage should count variable declarations as variables', t => {
 
 test('coverage should count variable declarations as statements', t => {
   t.plan(2);
-  runFixture('variable-declarations').then(({locations}) => {
+  runFixture('variable-declarations').then(locations => {
     const statementLocations = locations.filter(isStatement);
     t.equal(statementLocations.length, 6);
     t.equal(statementLocations.every(el => el.count === 1), true);
@@ -30,7 +30,7 @@ test('coverage should count variable declarations as statements', t => {
 
 test('coverage should count variable declarations', t => {
   t.plan(2);
-  runFixture('variable-declarations').then(({locations}) => {
+  runFixture('variable-declarations').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     t.equal(expressionLocations.length, 9);
     t.equal(expressionLocations.every(el => el.count === 1), true);

--- a/test/spec/while-statements.spec.js
+++ b/test/spec/while-statements.spec.js
@@ -8,7 +8,7 @@ import {isExpression, isStatement, isBranch} from './helpers/tag-assert';
 
 test('coverage should count while-statement statements', t => {
   t.plan(2);
-  runFixture('while-statements').then(({locations}) => {
+  runFixture('while-statements').then(locations => {
     const statementLocations = locations.filter(isStatement);
     const executedStatementLocations = statementLocations
       .filter(el => el.count === 1)
@@ -23,7 +23,7 @@ test('coverage should count while-statement statements', t => {
 
 test('coverage should count while-statement test expressions', t => {
   t.plan(2);
-  runFixture('while-statements').then(({locations}) => {
+  runFixture('while-statements').then(locations => {
     const expressionLocations = locations.filter(isExpression);
     const executedOnceExpressionLocations = expressionLocations
       .filter(el => el.count === 1)
@@ -38,7 +38,7 @@ test('coverage should count while-statement test expressions', t => {
 
 test('coverage should count while-statement branches', t => {
   t.plan(2);
-  runFixture('while-statements').then(({locations}) => {
+  runFixture('while-statements').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedOnceBranchLocations = branchLocations
       .filter(el => el.count === 1)
@@ -53,7 +53,7 @@ test('coverage should count while-statement branches', t => {
 
 test('coverage should count empty while-statement branches', t => {
   t.plan(3);
-  runFixture('while-statements-empty').then(({locations}) => {
+  runFixture('while-statements-empty').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedNeverBranchLocations = branchLocations
       .filter(el => el.count === 0);
@@ -71,7 +71,7 @@ test('coverage should count empty while-statement branches', t => {
 
 test('coverage should count while-statement branches without blocks', t => {
   t.plan(3);
-  runFixture('while-statements-no-block').then(({locations}) => {
+  runFixture('while-statements-no-block').then(locations => {
     const branchLocations = locations.filter(isBranch);
     const executedNeverBranchLocations = branchLocations
       .filter(el => el.count === 0);


### PR DESCRIPTION
Current coverage data is too verbose resulting in huge JSON files. This
commit uses the `codec` from esnext-coverage-analytics to compress data.

It also restructures coverage data object to allow for per-file and
per-project metadata.