### PR TITLE
feat(prelude): use relative paths to identify instrumented files

### DIFF
--- a/src/prelude.js
+++ b/src/prelude.js
@@ -11,7 +11,7 @@ export const defaultNamespace = '__coverage__';
 
 export default function prelude(state) {
   const {variable, locations} = getCoverageMeta(state);
-  const name = state.file.opts.filenameRelative;
+  const name = state.file.opts.filenameRelative.replace(`${process.cwd()}${path.sep}`, '');
   const namespace = state.opts && state.opts.global || defaultNamespace;
   return render({
     VARIABLE: variable,

--- a/test/spec/helpers/run.js
+++ b/test/spec/helpers/run.js
@@ -6,6 +6,7 @@ import {defaultNamespace as namespace} from '../../../src/prelude';
 
 export default function runFixture(fixtureName) {
   const fixturePath = path.resolve(__dirname, `../../fixture/${fixtureName}.fixture.js`);
+  const relativeFixturePath = fixturePath.replace(`${process.cwd()}${path.sep}`, '');
   return transform(fixturePath)
     .then(({code}) => {
       const sandbox = {
@@ -14,7 +15,7 @@ export default function runFixture(fixtureName) {
         exports: {}
       };
       runInNewContext(code, sandbox);
-      const fileCoverage = sandbox.global[namespace][fixturePath];
+      const fileCoverage = sandbox.global[namespace][relativeFixturePath];
       return codec.decodeAll(fileCoverage);
     })
     .catch(error => console.error(error)); // eslint-disable-line no-console


### PR DESCRIPTION
Full paths are too verbose and unnecessary.